### PR TITLE
Updated naive generator to store the correct answer

### DIFF
--- a/parsons-tool-frontend/src/generators/naiveGenerator.js
+++ b/parsons-tool-frontend/src/generators/naiveGenerator.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-useless-concat
-export const FADE_TOKEN = '$$fade$$';
+export const FADE_TOKEN = '$$';
 
 export const generateParsons = (sourceCode) =>
   sourceCode
@@ -10,13 +10,20 @@ export const generateParsons = (sourceCode) =>
 export const mapLine = (text, id) => {
   let parsedText = text;
   const fadedIndices = [];
+  const answers = [];
   while (parsedText.indexOf(FADE_TOKEN) >= 0) {
     const i = parsedText.indexOf(FADE_TOKEN);
+    const j = parsedText.indexOf(FADE_TOKEN, i + 2);
+
+    if (j < 0) {
+      break;
+    }
+    answers.push(parsedText.substring(i + 2, j));
     fadedIndices.push(i);
-    parsedText = parsedText.replace(FADE_TOKEN, '');
+    parsedText = replaceRange(parsedText, i, j + 2, '');
   }
   const indentation = Math.floor(countSpaces(parsedText) / 2);
-  return { id: `block-${id}`, text: parsedText, fadedIndices, indentation };
+  return { id: `block-${id}`, text: parsedText, fadedIndices, indentation, answers };
 };
 
 const countSpaces = (line) => {
@@ -37,6 +44,10 @@ const countSpaces = (line) => {
     i++;
   }
   return count;
+};
+
+const replaceRange = (str, start, end, substitute) => {
+  return str.substring(0, start) + substitute + str.substring(end);
 };
 
 export default generateParsons;


### PR DESCRIPTION
Modified the naive generator to store the correct answer of the faded index; this can be used for testing users' submissions against the correct solution. Also allows for a simple checker to be implemented

![image](https://user-images.githubusercontent.com/66896513/180368540-81aece95-d9dd-49e3-bea1-858b5fa7100d.png)
