### PR TITLE
Modified box height to be dependent on number of blocks

### DIFF
--- a/parsons-tool-frontend/src/components/parsonsProblem.js
+++ b/parsons-tool-frontend/src/components/parsonsProblem.js
@@ -116,12 +116,18 @@ function ParsonsProblem({ problem, problemId }) {
   return (
     <div className="App flex w-full">
       <DndContext sensors={sensors} onDragEnd={dragEnd} onDragStart={dragStart} onDragCancel={() => setActiveId(null)}>
-        <Space name={'problem'} blocks={state.problem.map((val) => state.blocks[val])} setInput={setInput} />
+        <Space
+          name={'problem'}
+          blocks={state.problem.map((val) => state.blocks[val])}
+          setInput={setInput}
+          height={problem.blocks.length}
+        />
         <Space
           name={'solution'}
           blocks={state.solution.map((val) => state.blocks[val])}
           setInput={setInput}
           enableHorizontal={true}
+          height={problem.blocks.length}
         />
         <DragOverlay dropAnimation={null}>
           {activeId ? (

--- a/parsons-tool-frontend/src/components/space/Space.js
+++ b/parsons-tool-frontend/src/components/space/Space.js
@@ -4,7 +4,7 @@ import Block from '../blocks/Block';
 import { SortableContext } from '@dnd-kit/sortable';
 import { useDroppable } from '@dnd-kit/core';
 
-const Space = ({ name, blocks, matches, enableHorizontal, setInput }) => {
+const Space = ({ name, blocks, matches, enableHorizontal, setInput, height }) => {
   const { setNodeRef } = useDroppable({
     id: name,
   });
@@ -26,7 +26,8 @@ const Space = ({ name, blocks, matches, enableHorizontal, setInput }) => {
   );
   return (
     <div
-      className="p-2 ml-2 mr-2 w-1/2 h-96 overflow-auto border-solid rounded-lg border-2 border-gray-400"
+      className="p-2 ml-2 mr-2 w-1/2 overflow-auto border-solid rounded-lg border-2 border-gray-400"
+      style={{ height: height * 3.45 + 'rem' }}
       ref={setNodeRef}
     >
       <SortableContext items={blocks} id={name}>


### PR DESCRIPTION
- uses the number of blocks in a problem which is passed in as a height field to the space components.
- The space component sets the height as = (num of blocks * 3.45)rem, this number was chosen as it helped prevent any scrollbar from appearing for any of the examples used, it may still need to be tweaked in the future if new problems are used