### PR TITLE
Fix problem with first execution not being logged

### DIFF
--- a/parsons-tool-frontend/src/hooks/usePost.js
+++ b/parsons-tool-frontend/src/hooks/usePost.js
@@ -13,7 +13,7 @@ export default function usePost(url) {
       const res = await axios.post(url, data);
       setResponse(res);
       setLoading(false);
-      postCallback();
+      postCallback(res);
     } catch {
       setLoading(false);
       setError(true);

--- a/parsons-tool-frontend/src/pages/ProblemEvaluation.js
+++ b/parsons-tool-frontend/src/pages/ProblemEvaluation.js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import ParsonsProblem from '../components/parsonsProblem';
 import { useBackend } from '../data/BackendContext';
@@ -17,6 +18,13 @@ export default function ProblemEvaluation() {
   const problem = location.state.problem;
 
   const navigate = useNavigate();
+
+  const executionResultCallback = useCallback(
+    (res) => {
+      logExecution(res.data);
+    },
+    [logExecution],
+  );
 
   const submitSolution = () => {
     logSubmission();
@@ -38,12 +46,6 @@ export default function ProblemEvaluation() {
     resetLogging();
     executionClear();
     navigate('/summary');
-  };
-
-  const executionResultCallback = () => {
-    if (executionResponse) {
-      logExecution(executionResponse.data);
-    }
   };
 
   return (


### PR DESCRIPTION
Problem was caused by the logExecution call depending on the previous component's respons which will always be null the first time.
So technically the problem was that the previous execution result would be the one logged every time.