### PR TITLE
Make the Jobe server restart in case of failure

### DIFF
--- a/parsons-tool-backend/docker-compose.yml
+++ b/parsons-tool-backend/docker-compose.yml
@@ -21,3 +21,4 @@ services:
       - 27017:27017
   jobe:
     image: trampgeek/jobeinabox
+    restart: always


### PR DESCRIPTION
During the reboot process, Jobe for some reason does not start back up.
This change causes docker compose to force the server to start back up if it fails for some reason.
The intention is to make the hosted service more resilient.