### PR TITLE
Add datalog execution result script

### DIFF
--- a/parsons-tool-backend/package.json
+++ b/parsons-tool-backend/package.json
@@ -7,7 +7,8 @@
     "start": "node -r esm ./src/server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "docker": "docker-compose up",
-    "init-db": "node -r esm ./src/init-db.js"
+    "init-db": "node -r esm ./src/init-db.js",
+    "execute-datalog": "node -r esm ./scripts/getDatalogResults.js"
   },
   "author": "",
   "license": "ISC",

--- a/parsons-tool-backend/scripts/getDatalogResults.js
+++ b/parsons-tool-backend/scripts/getDatalogResults.js
@@ -1,0 +1,51 @@
+import mongoose from 'mongoose';
+import ProblemSchema from '../src/database/ProblemSchema';
+import DataLogSchema from '../src/database/DataLogSchema';
+import axios from 'axios';
+
+const mongoDbUrl = process.env.MONGO_DB || 'mongodb://localhost:27017/parsons';
+const apiUrl = process.env.API_URL || 'https://api.parsons.hiru.dev/';
+
+const solveUrl = apiUrl + 'solve';
+const args = process.argv.slice(2);
+console.log('Args', args);
+
+async function main() {
+  await mongoose.connect(mongoDbUrl, { useNewUrlParser: true });
+  const output = {};
+
+  const ids =
+    args[0] === 'all' ? (await DataLogSchema.find({ result: { $exists: false } }, '_id')).map((r) => r._id) : args;
+
+  console.log('Ids to inspect: ', ids);
+  for (let id of ids) {
+    console.log('===');
+    console.log('Inspecting', id.toString());
+    const datalog = await DataLogSchema.findById(id);
+    const problem = await ProblemSchema.findById(datalog.blockState.initialProblem);
+    if (datalog.result) {
+      console.log('Already exists, skipping...');
+      continue;
+    }
+    const response = await axios({
+      url: solveUrl,
+      method: 'POST',
+      data: {
+        solution: datalog.blockState.solution,
+        blocks: datalog.blockState.blocks,
+        initialProblem: datalog.blockState.initialProblem,
+      },
+    });
+    const results = response.data;
+    const totalTests = problem.problem.tests.length;
+    const passedTets = Array.isArray(results) ? results.filter(({ result }) => result === 'correct').length : 0;
+    console.log(passedTets, '/', totalTests);
+    const res = `${passedTets}/${totalTests}`;
+    output[id.toString()] = res;
+
+    await DataLogSchema.updateOne({ _id: id }, { $set: { result: res } });
+  }
+  console.log(output);
+}
+
+main();

--- a/parsons-tool-backend/src/database/DataLogSchema.js
+++ b/parsons-tool-backend/src/database/DataLogSchema.js
@@ -17,6 +17,7 @@ const dataLogSchema = new Schema({
     type: Date,
     required: true,
   },
+  result: String,
   dataEvents: {
     type: [
       {

--- a/parsons-tool-backend/src/routes/api/solve.js
+++ b/parsons-tool-backend/src/routes/api/solve.js
@@ -25,7 +25,7 @@ router.post('/', async (req, res) => {
     return res.status(401);
   }
   const problem = await ProblemSchema.findById(req.body.initialProblem);
-  const language = problem.language;
+  const language = problem.language === 'Python' ? 'python3' : problem.language;
   const tests = problem.problem.tests;
   const testRunnerScript = testRunnerGenerator(language)(tests);
   const expectedOutput = tests.map(({ outputs }) => outputs.filter((v, i) => i % 2 === 0).join('\n'));


### PR DESCRIPTION
This script will go through the specified ids (or all unexecuted datalogs if "all" is given in as an argument) and execute them.
The results are set in the database itself.

Example usage
```
MONGO_DB="<MONGO URL>" API_URL="http://localhost:3001/" yarn workspace parsons-tool-backend execute-datalog all
```

Merge #111 before approving this PR